### PR TITLE
fix: type now return a type

### DIFF
--- a/algo.typ
+++ b/algo.typ
@@ -167,7 +167,7 @@
     if title != none {
       set text(1.1em)
 
-      if type(title) == "string" {
+      if type(title) == str {
         underline(smallcaps(title))
       } else {
         title
@@ -184,7 +184,7 @@
       $($
 
       for (i, param) in parameters.enumerate() {
-        if type(param) == "string" {
+        if type(param) == str {
           math.italic(param)
         } else {
           param


### PR DESCRIPTION
Hi, I create a PR to fix the type **warning** after typst `0.7`. And prepare for typst `0.14`.

![image](https://github.com/user-attachments/assets/bf9e414a-0181-4bfa-93ac-f700a373a167)


Here is a copy from [doc](https://typst.app/docs/reference/foundations/type/#:~:text=Apart%20from%20basic%20types%20for%20numeric%20values%20and,elements%20like%20headings%20and%20shapes%2C%20and%20style%20information.)
# Compatibility
In Typst 0.7 and lower, the type function returned a string instead of a type. Compatibility with the old way will remain until Typst 0.14 to give package authors time to upgrade.

Checks like int == "integer" evaluate to true
Adding/joining a type and string will yield a string
The in operator on a type and a dictionary will evaluate to true if the dictionary has a string key matching the type's name