### PR TITLE
Added `front-matter` parameter to `#algo()`.

### DIFF
--- a/algo.typ
+++ b/algo.typ
@@ -655,6 +655,8 @@
 //   body: Algorithm content.
 //   header: Algorithm header. Overrides title and parameters.
 //   title: Algorithm title. Ignored if header is not none.
+//   front-matter: Content to appear after the header but before the
+//     algorithm body, above the line numbers.
 //   Parameters: Array of parameters. Ignored if header is not none.
 //   line-numbers: Whether to have line numbers.
 //   strong-keywords: Whether to have bold keywords.

--- a/algo.typ
+++ b/algo.typ
@@ -752,7 +752,7 @@
     #set align(start + top)
     #algo-header
     #v(weak: true, row-gutter)
-    front-matter
+    #front-matter
     #align(left, algo-table)
   ]
 

--- a/algo.typ
+++ b/algo.typ
@@ -684,6 +684,7 @@
   header: none,
   title: none,
   parameters: (),
+  front-matter: none,
   line-numbers: true,
   strong-keywords: true,
   keywords: _algo-default-keywords,
@@ -751,6 +752,7 @@
     #set align(start + top)
     #algo-header
     #v(weak: true, row-gutter)
+    front-matter
     #align(left, algo-table)
   ]
 


### PR DESCRIPTION
Added `front-matter` parameter to `#algo()` which places given content below the header, but above the algorithm table and line numbers.

Example:

```typst
#algo(
  title: "Fib",
  parameters: ("n",),
  front-matter: [
    *Input*: The number in the Fibonacci sequence $n$ to generate.\
    *Output*: The $n$th number in the Fibonacci sequence.
  ]
)[
  if $n < 0$:#i\
    return null#d\
  if $n = 0$ or $n = 1$:#i\
    return $n$#d\
  \
  let $x <- 0$\
  let $y <- 1$\
  for $i <- 2$ to $n-1$:#i\
    let $z <- x+y$\
    $x <- y$\
    $y <- z$#d\
    \
  return $x+y$
]
```
Outputs the following:
![typst_alg_fib](https://github.com/user-attachments/assets/2af43c7e-0d88-4048-b710-ae399126bc93)
